### PR TITLE
Emerald vs. Smaragd

### DIFF
--- a/language/de-DE/de-DE.ini
+++ b/language/de-DE/de-DE.ini
@@ -73,7 +73,7 @@ APP_REQUEST_OPENSSL_DETAIL="CSR details"
 
 ;Result
 APP_RESULT_1="Compliant to CAB OV Requirements"
-APP_RESULT_3="Valid for Swisscom SSL Smaragd"
+APP_RESULT_3="Valid for Swisscom SSL Emerald (named 'Smaragd')"
 
 ;Submit
 APP_SUBMIT_BTN_REMOVE="Clear form"
@@ -117,4 +117,4 @@ APP_ERROR_23="the * is only permitted on a valid domain."
 
 ;Text
 APP_TEST_1="your certificate request does not meet the CAB OV requirements."
-APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald certificate."
+APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald (named 'Smaragd') certificate."

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -73,7 +73,7 @@ APP_REQUEST_OPENSSL_DETAIL="CSR details"
 
 ;Result
 APP_RESULT_1="Compliant to CAB OV Requirements"
-APP_RESULT_3="Valid for Swisscom SSL Smaragd"
+APP_RESULT_3="Valid for Swisscom SSL Emerald (named 'Smaragd')"
 
 ;Submit
 APP_SUBMIT_BTN_REMOVE="Clear form"
@@ -117,4 +117,4 @@ APP_ERROR_23="the * is only permitted on a valid domain."
 
 ;Text
 APP_TEST_1="your certificate request does not meet the CAB OV requirements."
-APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald certificate."
+APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald (named 'Smaragd') certificate."

--- a/language/fr-FR/fr-FR.ini
+++ b/language/fr-FR/fr-FR.ini
@@ -73,7 +73,7 @@ APP_REQUEST_OPENSSL_DETAIL="CSR details"
 
 ;Result
 APP_RESULT_1="Compliant to CAB OV Requirements"
-APP_RESULT_3="Valid for Swisscom SSL Smaragd"
+APP_RESULT_3="Valid for Swisscom SSL Emerald (named 'Smaragd')"
 
 ;Submit
 APP_SUBMIT_BTN_REMOVE="Clear form"
@@ -117,4 +117,4 @@ APP_ERROR_23="the * is only permitted on a valid domain."
 
 ;Text
 APP_TEST_1="your certificate request does not meet the CAB OV requirements."
-APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald certificate."
+APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald (named 'Smaragd') certificate."

--- a/language/it-IT/it-IT.ini
+++ b/language/it-IT/it-IT.ini
@@ -73,7 +73,7 @@ APP_REQUEST_OPENSSL_DETAIL="CSR details"
 
 ;Result
 APP_RESULT_1="Compliant to CAB OV Requirements"
-APP_RESULT_3="Valid for Swisscom SSL Smaragd"
+APP_RESULT_3="Valid for Swisscom SSL Emerald (named 'Smaragd')"
 
 ;Submit
 APP_SUBMIT_BTN_REMOVE="Clear form"
@@ -117,4 +117,4 @@ APP_ERROR_23="the * is only permitted on a valid domain."
 
 ;Text
 APP_TEST_1="your certificate request does not meet the CAB OV requirements."
-APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald certificate."
+APP_TEST_3="your request does not meet the requirements for a Swisscom SSL Emerald (named 'Smaragd') certificate."


### PR DESCRIPTION
In one text it's written Smaragd (german and as in the certificate itself), in another Emerald (english).
Commit to make it more clear by writing Emerald (as in English like the rest of the text) but add "Smaragd" as people more likely know it by that name.
Maybe it's useful.
